### PR TITLE
Use instance connection method in Table#destroy

### DIFF
--- a/lib/with_model/table.rb
+++ b/lib/with_model/table.rb
@@ -14,7 +14,7 @@ module WithModel
     end
 
     def destroy
-      ActiveRecord::Base.connection.drop_table(@name)
+      connection.drop_table(@name)
     end
 
     private


### PR DESCRIPTION
I noticed that `WithModel::Table` has a private `connection` method that wraps `ActiveRecord::Base.connection`. This method is used everywhere, except in `Table#destroy`.
